### PR TITLE
prevent browser errors by firing callbacks only when defined

### DIFF
--- a/jquery.listfilter.js
+++ b/jquery.listfilter.js
@@ -72,7 +72,10 @@
 
                     // Display them
                     match.show();
-                    that.settings.callback();
+                    // Only fire if a callback was actually defined
+                    if (that.settings.callback) {
+                        that.settings.callback();
+                    }
                 }).on('keyup', function () {
                     filter.change();
                 });


### PR DESCRIPTION
When using this plugin, I get some errors in the browser console warning that a callback could not be fired (the actual error is `TypeError: that.settings.callback is not a function`).

This happens because the plugin does not check if a callback was set before trying to fire it after it has filtered the list.

I just added a check to be sure the callback is set before actually calling it.